### PR TITLE
feat(#6): layouts slider & badge + design avancé header/reviews

### DIFF
--- a/apps/backend/public/widget.js
+++ b/apps/backend/public/widget.js
@@ -283,17 +283,12 @@
     var showDate = config.showDate !== false;
     var truncateText = config.truncateText !== false;
 
-    var bg = isDark ? '#1F2937' : '#FFFFFF';
-    var border = isDark ? '#374151' : '#E5E7EB';
     var subColor = isDark ? '#9CA3AF' : '#6B7280';
 
     container.innerHTML = '';
     container.style.fontFamily = 'system-ui,-apple-system,sans-serif';
 
-    var wrapper = createElement('div', [
-      'background:' + bg, 'border-radius:12px',
-      'padding:24px', 'border:1px solid ' + border,
-    ].join(';'));
+    var wrapper = createElement('div', 'border-radius:12px;padding:24px');
 
     if (showHeader) {
       var title = createElement('h3', 'color:' + accent + ';margin:0 0 20px;font-size:18px;font-weight:700');

--- a/apps/backend/public/widget.js
+++ b/apps/backend/public/widget.js
@@ -69,7 +69,30 @@
     return wrapper;
   }
 
-  function renderCardList(review, isDark) {
+  function renderAvatar(url, size, isDark) {
+    if (url) {
+      var img = document.createElement('img');
+      img.src = url;
+      img.style.cssText = 'width:' + size + 'px;height:' + size + 'px;border-radius:50%;object-fit:cover;flex-shrink:0';
+      img.onerror = function () { this.style.display = 'none'; };
+      return img;
+    }
+    return null;
+  }
+
+  function renderReviewText(text, truncate, color, fontSize) {
+    var p = createElement('p', 'color:' + color + ';margin:0;font-size:' + (fontSize || 14) + 'px;line-height:1.6');
+    p.textContent = text;
+    if (truncate) {
+      p.style.display = '-webkit-box';
+      p.style.webkitLineClamp = '3';
+      p.style.webkitBoxOrient = 'vertical';
+      p.style.overflow = 'hidden';
+    }
+    return p;
+  }
+
+  function renderCardList(review, isDark, showAvatar, showDate, truncateText) {
     var bg = isDark ? '#111827' : '#F9FAFB';
     var border = isDark ? '#374151' : '#E5E7EB';
     var textColor = isDark ? '#F9FAFB' : '#111827';
@@ -81,12 +104,14 @@
     ].join(';'));
 
     var header = createElement('div', 'display:flex;align-items:center;gap:10px;margin-bottom:10px');
-    if (review.profile_photo_url) {
-      var img = document.createElement('img');
-      img.src = review.profile_photo_url;
-      img.style.cssText = 'width:36px;height:36px;border-radius:50%;object-fit:cover;flex-shrink:0';
-      img.onerror = function () { this.style.display = 'none'; };
-      header.appendChild(img);
+    if (showAvatar) {
+      var img = renderAvatar(review.profile_photo_url, 36, isDark);
+      if (img) {
+        header.appendChild(img);
+      } else {
+        var placeholder = createElement('div', 'width:36px;height:36px;border-radius:50%;background:' + (isDark ? '#374151' : '#E5E7EB') + ';flex-shrink:0');
+        header.appendChild(placeholder);
+      }
     }
     var authorInfo = createElement('div', '');
     var authorName = createElement('div', 'font-weight:600;font-size:14px;color:' + textColor);
@@ -97,19 +122,15 @@
     card.appendChild(header);
 
     if (review.text) {
-      var reviewText = createElement('p', 'color:' + subColor + ';margin:0;font-size:14px;line-height:1.6');
-      reviewText.textContent = review.text;
-      card.appendChild(reviewText);
+      card.appendChild(renderReviewText(review.text, truncateText, subColor, 14));
     }
-    if (review.relative_time_description) {
-      var timeEl = createElement('div', 'color:' + subColor + ';font-size:12px;margin-top:8px');
-      timeEl.textContent = review.relative_time_description;
-      card.appendChild(timeEl);
+    if (showDate && review.relative_time_description) {
+      card.appendChild(createElement('div', 'color:' + subColor + ';font-size:12px;margin-top:8px', review.relative_time_description));
     }
     return card;
   }
 
-  function renderCardGrid(review, isDark) {
+  function renderCardGrid(review, isDark, showAvatar, showDate, truncateText) {
     var bg = isDark ? '#111827' : '#F9FAFB';
     var border = isDark ? '#374151' : '#E5E7EB';
     var textColor = isDark ? '#F9FAFB' : '#111827';
@@ -121,12 +142,14 @@
     ].join(';'));
 
     var header = createElement('div', 'display:flex;align-items:center;gap:10px;margin-bottom:10px');
-    if (review.profile_photo_url) {
-      var img = document.createElement('img');
-      img.src = review.profile_photo_url;
-      img.style.cssText = 'width:32px;height:32px;border-radius:50%;object-fit:cover;flex-shrink:0';
-      img.onerror = function () { this.style.display = 'none'; };
-      header.appendChild(img);
+    if (showAvatar) {
+      var img = renderAvatar(review.profile_photo_url, 32, isDark);
+      if (img) {
+        header.appendChild(img);
+      } else {
+        var placeholder = createElement('div', 'width:32px;height:32px;border-radius:50%;background:' + (isDark ? '#374151' : '#E5E7EB') + ';flex-shrink:0');
+        header.appendChild(placeholder);
+      }
     }
     var authorInfo = createElement('div', '');
     var authorName = createElement('div', 'font-weight:600;font-size:13px;color:' + textColor);
@@ -137,19 +160,15 @@
     card.appendChild(header);
 
     if (review.text) {
-      var reviewText = createElement('p', 'color:' + subColor + ';margin:0;font-size:13px;line-height:1.5;flex:1');
-      reviewText.textContent = review.text;
-      card.appendChild(reviewText);
+      card.appendChild(renderReviewText(review.text, truncateText, subColor, 13));
     }
-    if (review.relative_time_description) {
-      var timeEl = createElement('div', 'color:' + subColor + ';font-size:11px;margin-top:8px');
-      timeEl.textContent = review.relative_time_description;
-      card.appendChild(timeEl);
+    if (showDate && review.relative_time_description) {
+      card.appendChild(createElement('div', 'color:' + subColor + ';font-size:11px;margin-top:8px', review.relative_time_description));
     }
     return card;
   }
 
-  function renderCardStars(review, isDark) {
+  function renderCardStars(review, isDark, showAvatar, showDate) {
     var border = isDark ? '#374151' : '#E5E7EB';
     var textColor = isDark ? '#F9FAFB' : '#111827';
     var subColor = isDark ? '#9CA3AF' : '#6B7280';
@@ -159,23 +178,98 @@
       'padding:10px 0', 'border-bottom:1px solid ' + border,
     ].join(';'));
 
-    if (review.profile_photo_url) {
-      var img = document.createElement('img');
-      img.src = review.profile_photo_url;
-      img.style.cssText = 'width:32px;height:32px;border-radius:50%;object-fit:cover;flex-shrink:0';
-      img.onerror = function () { this.style.display = 'none'; };
-      card.appendChild(img);
+    if (showAvatar) {
+      var img = renderAvatar(review.profile_photo_url, 32, isDark);
+      if (img) {
+        card.appendChild(img);
+      } else {
+        var placeholder = createElement('div', 'width:32px;height:32px;border-radius:50%;background:' + (isDark ? '#374151' : '#E5E7EB') + ';flex-shrink:0');
+        card.appendChild(placeholder);
+      }
     }
     var name = createElement('span', 'font-weight:600;font-size:14px;color:' + textColor + ';flex:1');
     name.textContent = review.author_name;
     card.appendChild(name);
     card.appendChild(renderStars(review.rating));
-    if (review.relative_time_description) {
-      var time = createElement('span', 'font-size:12px;color:' + subColor + ';white-space:nowrap');
-      time.textContent = review.relative_time_description;
-      card.appendChild(time);
+    if (showDate && review.relative_time_description) {
+      card.appendChild(createElement('span', 'font-size:12px;color:' + subColor + ';white-space:nowrap', review.relative_time_description));
     }
     return card;
+  }
+
+  function renderCardSlider(review, isDark, showAvatar, showDate, truncateText) {
+    var bg = isDark ? '#111827' : '#F9FAFB';
+    var border = isDark ? '#374151' : '#E5E7EB';
+    var textColor = isDark ? '#F9FAFB' : '#111827';
+    var subColor = isDark ? '#9CA3AF' : '#6B7280';
+
+    var card = createElement('div', [
+      'padding:16px', 'background:' + bg, 'border-radius:8px',
+      'border:1px solid ' + border, 'min-width:260px', 'max-width:300px',
+      'flex-shrink:0', 'scroll-snap-align:start', 'display:flex', 'flex-direction:column',
+    ].join(';'));
+
+    var header = createElement('div', 'display:flex;align-items:center;gap:10px;margin-bottom:10px');
+    if (showAvatar) {
+      var img = renderAvatar(review.profile_photo_url, 36, isDark);
+      if (img) {
+        header.appendChild(img);
+      } else {
+        var placeholder = createElement('div', 'width:36px;height:36px;border-radius:50%;background:' + (isDark ? '#374151' : '#E5E7EB') + ';flex-shrink:0');
+        header.appendChild(placeholder);
+      }
+    }
+    var authorInfo = createElement('div', '');
+    var authorName = createElement('div', 'font-weight:600;font-size:14px;color:' + textColor);
+    authorName.textContent = review.author_name;
+    authorInfo.appendChild(authorName);
+    authorInfo.appendChild(renderStars(review.rating));
+    header.appendChild(authorInfo);
+    card.appendChild(header);
+
+    if (review.text) {
+      card.appendChild(renderReviewText(review.text, truncateText, subColor, 14));
+    }
+    if (showDate && review.relative_time_description) {
+      card.appendChild(createElement('div', 'color:' + subColor + ';font-size:12px;margin-top:8px', review.relative_time_description));
+    }
+    return card;
+  }
+
+  function renderBadge(reviews, accent, isDark) {
+    var bg = isDark ? '#111827' : '#F9FAFB';
+    var border = isDark ? '#374151' : '#E5E7EB';
+    var subColor = isDark ? '#9CA3AF' : '#6B7280';
+
+    var total = reviews.reduce(function (s, r) { return s + r.rating; }, 0);
+    var avg = reviews.length > 0 ? total / reviews.length : 5;
+    var rounded = Math.round(avg);
+
+    var badge = createElement('div', [
+      'display:inline-flex', 'align-items:center', 'gap:12px',
+      'padding:12px 20px', 'background:' + bg, 'border-radius:100px',
+      'border:1px solid ' + border,
+    ].join(';'));
+
+    badge.appendChild(createElement('span', 'font-size:24px;font-weight:700;color:' + accent, avg.toFixed(1)));
+
+    var starsBlock = createElement('div', '');
+    var starsRow = createElement('span', 'font-size:18px;letter-spacing:-2px');
+    for (var i = 1; i <= 5; i++) {
+      starsRow.appendChild(createElement('span', 'color:' + (i <= rounded ? '#FBBF24' : '#D1D5DB'), '\u2605'));
+    }
+    starsBlock.appendChild(starsRow);
+    starsBlock.appendChild(createElement('div', 'font-size:11px;color:' + subColor + ';margin-top:2px', reviews.length + ' avis Google'));
+    badge.appendChild(starsBlock);
+
+    badge.appendChild(createElement('div', 'width:1px;height:36px;background:' + border));
+
+    var cta = createElement('div', 'text-align:center');
+    cta.appendChild(createElement('div', 'font-size:11px;color:' + subColor, 'Voir les avis'));
+    cta.appendChild(createElement('div', 'font-size:10px;color:' + subColor + ';margin-top:2px;font-style:italic', 'Google'));
+    badge.appendChild(cta);
+
+    return badge;
   }
 
   function renderWidget(container, data) {
@@ -183,6 +277,11 @@
     var isDark = config.theme === 'dark';
     var accent = config.accentColor || '#4F46E5';
     var layout = config.layout || 'list';
+    var showHeader = config.showHeader !== false;
+    var headerTitle = config.headerTitle || '';
+    var showAvatar = config.showAvatar !== false;
+    var showDate = config.showDate !== false;
+    var truncateText = config.truncateText !== false;
 
     var bg = isDark ? '#1F2937' : '#FFFFFF';
     var border = isDark ? '#374151' : '#E5E7EB';
@@ -196,23 +295,34 @@
       'padding:24px', 'border:1px solid ' + border,
     ].join(';'));
 
-    var title = createElement('h3', 'color:' + accent + ';margin:0 0 20px;font-size:18px;font-weight:700');
-    title.textContent = data.widget.name;
-    wrapper.appendChild(title);
+    if (showHeader) {
+      var title = createElement('h3', 'color:' + accent + ';margin:0 0 20px;font-size:18px;font-weight:700');
+      title.textContent = headerTitle || data.widget.name;
+      wrapper.appendChild(title);
+    }
 
     if (!data.reviews || data.reviews.length === 0) {
       wrapper.appendChild(createElement('p', 'color:' + subColor, 'Aucun avis disponible.'));
+    } else if (layout === 'badge') {
+      wrapper.appendChild(renderBadge(data.reviews, accent, isDark));
+    } else if (layout === 'slider') {
+      var sliderEl = createElement('div', [
+        'display:flex', 'gap:12px', 'overflow-x:auto',
+        'scroll-snap-type:x mandatory', 'padding-bottom:8px',
+      ].join(';'));
+      data.reviews.forEach(function (r) { sliderEl.appendChild(renderCardSlider(r, isDark, showAvatar, showDate, truncateText)); });
+      wrapper.appendChild(sliderEl);
     } else if (layout === 'grid') {
       var grid = createElement('div', 'display:grid;grid-template-columns:1fr 1fr;gap:12px');
-      data.reviews.forEach(function (r) { grid.appendChild(renderCardGrid(r, isDark)); });
+      data.reviews.forEach(function (r) { grid.appendChild(renderCardGrid(r, isDark, showAvatar, showDate, truncateText)); });
       wrapper.appendChild(grid);
     } else if (layout === 'stars') {
       var list = createElement('div', '');
-      data.reviews.forEach(function (r) { list.appendChild(renderCardStars(r, isDark)); });
+      data.reviews.forEach(function (r) { list.appendChild(renderCardStars(r, isDark, showAvatar, showDate)); });
       wrapper.appendChild(list);
     } else {
       var list = createElement('div', '');
-      data.reviews.forEach(function (r) { list.appendChild(renderCardList(r, isDark)); });
+      data.reviews.forEach(function (r) { list.appendChild(renderCardList(r, isDark, showAvatar, showDate, truncateText)); });
       wrapper.appendChild(list);
     }
 

--- a/apps/frontend/src/pages/NewWidget.tsx
+++ b/apps/frontend/src/pages/NewWidget.tsx
@@ -17,7 +17,7 @@ interface PlacePrediction {
   secondary_text: string;
 }
 
-interface FormState {
+export interface FormState {
   name: string;
   placeId: string;
   placeName: string;
@@ -27,19 +27,47 @@ interface FormState {
   minRating: number;
   theme: string;
   accentColor: string;
+  // Header design
+  showHeader: boolean;
+  headerTitle: string;
+  // Reviews design
+  showAvatar: boolean;
+  showDate: boolean;
+  truncateText: boolean;
 }
 
-const MOCK_REVIEWS: Review[] = [
-  { author_name: 'Marie Dupont', rating: 5, text: 'Excellent service, personnel très accueillant ! Je recommande vivement.', profile_photo_url: '', relative_time_description: 'il y a 2 semaines' },
+export const FORM_DEFAULTS: Omit<FormState, 'name' | 'placeId' | 'placeName' | 'placeDescription'> = {
+  layout: 'list',
+  maxReviews: 5,
+  minRating: 4,
+  theme: 'light',
+  accentColor: '#4F46E5',
+  showHeader: true,
+  headerTitle: '',
+  showAvatar: true,
+  showDate: true,
+  truncateText: true,
+};
+
+export const MOCK_REVIEWS: Review[] = [
+  { author_name: 'Marie Dupont', rating: 5, text: 'Excellent service, personnel très accueillant ! Je recommande vivement à tous.', profile_photo_url: '', relative_time_description: 'il y a 2 semaines' },
   { author_name: 'Jean Martin', rating: 5, text: 'Très bonne expérience, je reviendrai sans hésiter.', profile_photo_url: '', relative_time_description: 'il y a 1 mois' },
   { author_name: 'Sophie Bernard', rating: 4, text: 'Bon rapport qualité-prix, personnel sympathique.', profile_photo_url: '', relative_time_description: 'il y a 3 semaines' },
 ];
 
+export const LAYOUTS = [
+  { value: 'list', label: 'Liste', desc: 'Cartes empilées' },
+  { value: 'grid', label: 'Grille', desc: '2 colonnes' },
+  { value: 'stars', label: 'Étoiles', desc: 'Vue compacte' },
+  { value: 'slider', label: 'Slider', desc: 'Défilement horiz.' },
+  { value: 'badge', label: 'Badge', desc: 'Synthèse compacte' },
+];
+
 const STEP_LABELS = ['Design', 'Localisation', 'Paramètres'];
 
-// --- Preview components ---
+// --- Shared preview components ---
 
-function StarRating({ rating }: { rating: number }) {
+export function StarRating({ rating }: { rating: number }) {
   return (
     <span>
       {[1,2,3,4,5].map(i => (
@@ -49,85 +77,152 @@ function StarRating({ rating }: { rating: number }) {
   );
 }
 
-function ReviewCardList({ review, isDark }: { review: Review; isDark: boolean }) {
+function ReviewText({ text, truncate, color }: { text: string; truncate: boolean; color: string }) {
+  const style: React.CSSProperties = { color, margin: 0, fontSize: 14, lineHeight: 1.6 };
+  if (truncate) {
+    Object.assign(style, { display: '-webkit-box', WebkitLineClamp: 3, WebkitBoxOrient: 'vertical', overflow: 'hidden' });
+  }
+  return <p style={style}>{text}</p>;
+}
+
+function CardHeader({ review, isDark, showAvatar, avatarSize = 36 }: {
+  review: Review; isDark: boolean; showAvatar: boolean; avatarSize?: number;
+}) {
+  const textColor = isDark ? '#F9FAFB' : '#111827';
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 10 }}>
+      {showAvatar && (
+        <div style={{ width: avatarSize, height: avatarSize, borderRadius: '50%', background: isDark ? '#374151' : '#E5E7EB', flexShrink: 0 }} />
+      )}
+      <div>
+        <div style={{ fontWeight: 600, fontSize: avatarSize === 32 ? 13 : 14, color: textColor }}>{review.author_name}</div>
+        <StarRating rating={review.rating} />
+      </div>
+    </div>
+  );
+}
+
+function ReviewCardList({ review, isDark, showAvatar, showDate, truncateText }: {
+  review: Review; isDark: boolean; showAvatar: boolean; showDate: boolean; truncateText: boolean;
+}) {
   const bg = isDark ? '#111827' : '#F9FAFB';
   const border = isDark ? '#374151' : '#E5E7EB';
-  const textColor = isDark ? '#F9FAFB' : '#111827';
   const subColor = isDark ? '#9CA3AF' : '#6B7280';
   return (
     <div style={{ padding: 16, background: bg, borderRadius: 8, border: `1px solid ${border}`, marginBottom: 12 }}>
-      <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 10 }}>
-        <div style={{ width: 36, height: 36, borderRadius: '50%', background: isDark ? '#374151' : '#E5E7EB', flexShrink: 0 }} />
-        <div>
-          <div style={{ fontWeight: 600, fontSize: 14, color: textColor }}>{review.author_name}</div>
-          <StarRating rating={review.rating} />
-        </div>
-      </div>
-      {review.text && <p style={{ color: subColor, margin: 0, fontSize: 14, lineHeight: 1.6 }}>{review.text}</p>}
-      {review.relative_time_description && <div style={{ color: subColor, fontSize: 12, marginTop: 8 }}>{review.relative_time_description}</div>}
+      <CardHeader review={review} isDark={isDark} showAvatar={showAvatar} />
+      {review.text && <ReviewText text={review.text} truncate={truncateText} color={subColor} />}
+      {showDate && review.relative_time_description && <div style={{ color: subColor, fontSize: 12, marginTop: 8 }}>{review.relative_time_description}</div>}
     </div>
   );
 }
 
-function ReviewCardGrid({ review, isDark }: { review: Review; isDark: boolean }) {
+function ReviewCardGrid({ review, isDark, showAvatar, showDate, truncateText }: {
+  review: Review; isDark: boolean; showAvatar: boolean; showDate: boolean; truncateText: boolean;
+}) {
   const bg = isDark ? '#111827' : '#F9FAFB';
   const border = isDark ? '#374151' : '#E5E7EB';
-  const textColor = isDark ? '#F9FAFB' : '#111827';
   const subColor = isDark ? '#9CA3AF' : '#6B7280';
   return (
     <div style={{ padding: 16, background: bg, borderRadius: 8, border: `1px solid ${border}`, display: 'flex', flexDirection: 'column' }}>
-      <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 10 }}>
-        <div style={{ width: 32, height: 32, borderRadius: '50%', background: isDark ? '#374151' : '#E5E7EB', flexShrink: 0 }} />
-        <div>
-          <div style={{ fontWeight: 600, fontSize: 13, color: textColor }}>{review.author_name}</div>
-          <StarRating rating={review.rating} />
-        </div>
-      </div>
-      {review.text && <p style={{ color: subColor, margin: 0, fontSize: 13, lineHeight: 1.5, flex: 1 }}>{review.text}</p>}
-      {review.relative_time_description && <div style={{ color: subColor, fontSize: 11, marginTop: 8 }}>{review.relative_time_description}</div>}
+      <CardHeader review={review} isDark={isDark} showAvatar={showAvatar} avatarSize={32} />
+      {review.text && <ReviewText text={review.text} truncate={truncateText} color={subColor} />}
+      {showDate && review.relative_time_description && <div style={{ color: subColor, fontSize: 11, marginTop: 8 }}>{review.relative_time_description}</div>}
     </div>
   );
 }
 
-function ReviewCardStars({ review, isDark }: { review: Review; isDark: boolean }) {
+function ReviewCardStars({ review, isDark, showAvatar, showDate }: {
+  review: Review; isDark: boolean; showAvatar: boolean; showDate: boolean;
+}) {
   const border = isDark ? '#374151' : '#E5E7EB';
   const textColor = isDark ? '#F9FAFB' : '#111827';
   const subColor = isDark ? '#9CA3AF' : '#6B7280';
   return (
     <div style={{ display: 'flex', alignItems: 'center', gap: 10, padding: '10px 0', borderBottom: `1px solid ${border}` }}>
-      <div style={{ width: 32, height: 32, borderRadius: '50%', background: isDark ? '#374151' : '#E5E7EB', flexShrink: 0 }} />
+      {showAvatar && <div style={{ width: 32, height: 32, borderRadius: '50%', background: isDark ? '#374151' : '#E5E7EB', flexShrink: 0 }} />}
       <span style={{ fontWeight: 600, fontSize: 14, color: textColor, flex: 1 }}>{review.author_name}</span>
       <StarRating rating={review.rating} />
-      {review.relative_time_description && <span style={{ fontSize: 12, color: subColor, whiteSpace: 'nowrap' }}>{review.relative_time_description}</span>}
+      {showDate && review.relative_time_description && <span style={{ fontSize: 12, color: subColor, whiteSpace: 'nowrap' }}>{review.relative_time_description}</span>}
     </div>
   );
 }
 
-function LivePreview({ reviews, layout, theme, accentColor, widgetName }: {
+function ReviewCardSlider({ review, isDark, showAvatar, showDate, truncateText }: {
+  review: Review; isDark: boolean; showAvatar: boolean; showDate: boolean; truncateText: boolean;
+}) {
+  const bg = isDark ? '#111827' : '#F9FAFB';
+  const border = isDark ? '#374151' : '#E5E7EB';
+  const subColor = isDark ? '#9CA3AF' : '#6B7280';
+  return (
+    <div style={{ padding: 16, background: bg, borderRadius: 8, border: `1px solid ${border}`, minWidth: 260, maxWidth: 300, flexShrink: 0, scrollSnapAlign: 'start', display: 'flex', flexDirection: 'column' }}>
+      <CardHeader review={review} isDark={isDark} showAvatar={showAvatar} />
+      {review.text && <ReviewText text={review.text} truncate={truncateText} color={subColor} />}
+      {showDate && review.relative_time_description && <div style={{ color: subColor, fontSize: 12, marginTop: 8 }}>{review.relative_time_description}</div>}
+    </div>
+  );
+}
+
+function BadgePreview({ reviews, isDark, accentColor }: { reviews: Review[]; isDark: boolean; accentColor: string }) {
+  const bg = isDark ? '#111827' : '#F9FAFB';
+  const border = isDark ? '#374151' : '#E5E7EB';
+  const subColor = isDark ? '#9CA3AF' : '#6B7280';
+  const avg = reviews.length > 0 ? reviews.reduce((s, r) => s + r.rating, 0) / reviews.length : 5;
+  return (
+    <div style={{ display: 'inline-flex', alignItems: 'center', gap: 12, padding: '12px 20px', background: bg, borderRadius: 100, border: `1px solid ${border}` }}>
+      <span style={{ fontSize: 24, fontWeight: 700, color: accentColor }}>{avg.toFixed(1)}</span>
+      <div>
+        <span style={{ fontSize: 18, letterSpacing: -2 }}>
+          {[1,2,3,4,5].map(i => <span key={i} style={{ color: i <= Math.round(avg) ? '#FBBF24' : '#D1D5DB' }}>★</span>)}
+        </span>
+        <div style={{ fontSize: 11, color: subColor, marginTop: 2 }}>{reviews.length} avis Google</div>
+      </div>
+      <div style={{ width: 1, height: 36, background: border }} />
+      <div style={{ textAlign: 'center' }}>
+        <div style={{ fontSize: 11, color: subColor }}>Voir les avis</div>
+        <div style={{ fontSize: 10, color: subColor, marginTop: 2, fontStyle: 'italic' }}>Google</div>
+      </div>
+    </div>
+  );
+}
+
+export function LivePreview({ reviews, layout, theme, accentColor, widgetName, showHeader, headerTitle, showAvatar, showDate, truncateText }: {
   reviews: Review[]; layout: string; theme: string; accentColor: string; widgetName: string;
+  showHeader: boolean; headerTitle: string; showAvatar: boolean; showDate: boolean; truncateText: boolean;
 }) {
   const isDark = theme === 'dark';
   const bg = isDark ? '#1F2937' : '#FFFFFF';
   const border = isDark ? '#374151' : '#E5E7EB';
   const subColor = isDark ? '#9CA3AF' : '#6B7280';
+  const title = headerTitle || widgetName;
 
   function renderReviews() {
+    if (layout === 'badge') {
+      return <BadgePreview reviews={reviews} isDark={isDark} accentColor={accentColor} />;
+    }
+    if (layout === 'slider') {
+      return (
+        <div style={{ display: 'flex', gap: 12, overflowX: 'auto', scrollSnapType: 'x mandatory', paddingBottom: 8 }}>
+          {reviews.map((r, i) => <ReviewCardSlider key={i} review={r} isDark={isDark} showAvatar={showAvatar} showDate={showDate} truncateText={truncateText} />)}
+        </div>
+      );
+    }
     if (layout === 'grid') {
       return (
         <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 12 }}>
-          {reviews.map((r, i) => <ReviewCardGrid key={i} review={r} isDark={isDark} />)}
+          {reviews.map((r, i) => <ReviewCardGrid key={i} review={r} isDark={isDark} showAvatar={showAvatar} showDate={showDate} truncateText={truncateText} />)}
         </div>
       );
     }
     if (layout === 'stars') {
-      return <div>{reviews.map((r, i) => <ReviewCardStars key={i} review={r} isDark={isDark} />)}</div>;
+      return <div>{reviews.map((r, i) => <ReviewCardStars key={i} review={r} isDark={isDark} showAvatar={showAvatar} showDate={showDate} />)}</div>;
     }
-    return <div>{reviews.map((r, i) => <ReviewCardList key={i} review={r} isDark={isDark} />)}</div>;
+    return <div>{reviews.map((r, i) => <ReviewCardList key={i} review={r} isDark={isDark} showAvatar={showAvatar} showDate={showDate} truncateText={truncateText} />)}</div>;
   }
 
   return (
     <div style={{ fontFamily: 'system-ui,-apple-system,sans-serif', background: bg, borderRadius: 12, padding: 24, border: `1px solid ${border}` }}>
-      <h3 style={{ color: accentColor, margin: '0 0 20px', fontSize: 18, fontWeight: 700 }}>{widgetName}</h3>
+      {showHeader && <h3 style={{ color: accentColor, margin: '0 0 20px', fontSize: 18, fontWeight: 700 }}>{title}</h3>}
       {renderReviews()}
       <div style={{ textAlign: 'center', marginTop: 16, fontSize: 11, color: subColor }}>Powered by WebWidget</div>
     </div>
@@ -163,6 +258,18 @@ function StepIndicator({ current }: { current: number }) {
   );
 }
 
+export function Toggle({ checked, onChange }: { checked: boolean; onChange: (v: boolean) => void }) {
+  return (
+    <button
+      type="button"
+      onClick={() => onChange(!checked)}
+      className={`relative inline-flex h-5 w-9 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors ${checked ? 'bg-indigo-600' : 'bg-gray-200'}`}
+    >
+      <span className={`inline-block h-4 w-4 rounded-full bg-white shadow transition-transform ${checked ? 'translate-x-4' : 'translate-x-0'}`} />
+    </button>
+  );
+}
+
 // --- Main component ---
 
 export default function NewWidget() {
@@ -175,11 +282,7 @@ export default function NewWidget() {
     placeId: '',
     placeName: '',
     placeDescription: '',
-    layout: 'list',
-    maxReviews: 5,
-    minRating: 4,
-    theme: 'light',
-    accentColor: '#4F46E5',
+    ...FORM_DEFAULTS,
   });
 
   const [previewReviews, setPreviewReviews] = useState<Review[]>(MOCK_REVIEWS);
@@ -277,16 +380,23 @@ export default function NewWidget() {
     }
   }
 
-  const LAYOUTS = [
-    { value: 'list', label: 'Liste', desc: 'Cartes empilées' },
-    { value: 'grid', label: 'Grille', desc: '2 colonnes' },
-    { value: 'stars', label: 'Étoiles', desc: 'Vue compacte' },
-  ];
+  const previewProps = {
+    reviews: previewReviews.slice(0, form.maxReviews),
+    layout: form.layout,
+    theme: form.theme,
+    accentColor: form.accentColor,
+    widgetName: form.name || form.placeName || previewName,
+    showHeader: form.showHeader,
+    headerTitle: form.headerTitle,
+    showAvatar: form.showAvatar,
+    showDate: form.showDate,
+    truncateText: form.truncateText,
+  };
 
   return (
     <div className="min-h-screen bg-gray-50">
       <header className="bg-white border-b border-gray-200">
-        <div className="max-w-3xl mx-auto px-4 py-4 flex items-center gap-3">
+        <div className="max-w-6xl mx-auto px-4 py-4 flex items-center gap-3">
           <Link to="/" className="text-gray-400 hover:text-gray-600 text-lg leading-none">←</Link>
           <div>
             <h1 className="text-lg font-bold text-gray-900">Nouveau widget</h1>
@@ -295,197 +405,254 @@ export default function NewWidget() {
         </div>
       </header>
 
-      <main className="max-w-3xl mx-auto px-4 py-8">
+      <main className="max-w-6xl mx-auto px-4 py-8">
         <StepIndicator current={step} />
 
-        <div className="bg-white rounded-xl border border-gray-200 p-6">
+        <div className="flex flex-col xl:flex-row gap-6 items-start">
 
-          {/* Étape 1 — Design */}
-          {step === 1 && (
-            <div className="space-y-6">
-              <div>
-                <h2 className="font-semibold text-gray-900 mb-1">Choisissez un design</h2>
-                <p className="text-xs text-gray-400 mb-4">L'aperçu ci-dessous se met à jour en temps réel.</p>
-                <div className="grid grid-cols-3 gap-3">
-                  {LAYOUTS.map(l => (
-                    <button
-                      key={l.value}
-                      type="button"
-                      onClick={() => update('layout', l.value)}
-                      className={`p-3 rounded-lg border-2 text-left transition-all ${
-                        form.layout === l.value ? 'border-indigo-500 bg-indigo-50' : 'border-gray-200 hover:border-gray-300'
-                      }`}
-                    >
-                      <p className={`text-sm font-semibold ${form.layout === l.value ? 'text-indigo-600' : 'text-gray-700'}`}>{l.label}</p>
-                      <p className="text-xs text-gray-400">{l.desc}</p>
-                    </button>
-                  ))}
-                </div>
-              </div>
-              <div>
-                <p className="text-xs text-gray-500 mb-3 font-medium uppercase tracking-wide">Aperçu</p>
-                <LivePreview
-                  reviews={previewReviews.slice(0, form.maxReviews)}
-                  layout={form.layout}
-                  theme={form.theme}
-                  accentColor={form.accentColor}
-                  widgetName={previewName}
-                />
-              </div>
-            </div>
-          )}
+          {/* Left: form */}
+          <div className="w-full xl:flex-1 min-w-0">
+            <div className="bg-white rounded-xl border border-gray-200 p-6">
 
-          {/* Étape 2 — Localisation */}
-          {step === 2 && (
-            <div className="space-y-4">
-              <div>
-                <h2 className="font-semibold text-gray-900 mb-1">Quel établissement ?</h2>
-                <p className="text-xs text-gray-400 mb-4">Recherchez votre établissement par son nom.</p>
-              </div>
-              <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">Lieu</label>
-                <div className="relative" ref={dropdownRef}>
-                  <input
-                    type="text"
-                    value={search}
-                    onChange={e => handleSearchChange(e.target.value)}
-                    onFocus={() => suggestions.length > 0 && setShowDropdown(true)}
-                    placeholder="Ex: Boulangerie Martin, Paris…"
-                    className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
-                    autoComplete="off"
-                    autoFocus
-                  />
-                  {searching && <span className="absolute right-3 top-2.5 text-gray-400 text-xs">Recherche…</span>}
-                  {showDropdown && (
-                    <ul className="absolute z-10 mt-1 w-full bg-white border border-gray-200 rounded-lg shadow-lg max-h-56 overflow-y-auto">
-                      {suggestions.map(place => (
-                        <li
-                          key={place.place_id}
-                          onMouseDown={() => selectPlace(place)}
-                          className="px-4 py-3 cursor-pointer hover:bg-indigo-50 border-b border-gray-100 last:border-0"
+              {/* Étape 1 — Design */}
+              {step === 1 && (
+                <div className="space-y-6">
+                  {/* Layout */}
+                  <div>
+                    <h2 className="font-semibold text-gray-900 mb-1">Mise en page</h2>
+                    <p className="text-xs text-gray-400 mb-4">L'aperçu se met à jour en temps réel.</p>
+                    <div className="grid grid-cols-3 sm:grid-cols-5 gap-2">
+                      {LAYOUTS.map(l => (
+                        <button
+                          key={l.value}
+                          type="button"
+                          onClick={() => update('layout', l.value)}
+                          className={`p-3 rounded-lg border-2 text-left transition-all ${
+                            form.layout === l.value ? 'border-indigo-500 bg-indigo-50' : 'border-gray-200 hover:border-gray-300'
+                          }`}
                         >
-                          <p className="text-sm font-medium text-gray-900">{place.main_text}</p>
-                          <p className="text-xs text-gray-400">{place.secondary_text}</p>
-                        </li>
+                          <p className={`text-xs font-semibold ${form.layout === l.value ? 'text-indigo-600' : 'text-gray-700'}`}>{l.label}</p>
+                          <p className="text-xs text-gray-400 mt-0.5">{l.desc}</p>
+                        </button>
                       ))}
-                    </ul>
+                    </div>
+                  </div>
+
+                  {/* Theme + color */}
+                  <div className="grid grid-cols-2 gap-4">
+                    <div>
+                      <label className="block text-sm font-medium text-gray-700 mb-2">Thème</label>
+                      <div className="grid grid-cols-2 gap-2">
+                        {[{ value: 'light', label: 'Clair' }, { value: 'dark', label: 'Sombre' }].map(t => (
+                          <button
+                            key={t.value}
+                            type="button"
+                            onClick={() => update('theme', t.value)}
+                            className={`p-2 rounded-lg border-2 text-xs font-medium transition-all ${
+                              form.theme === t.value ? 'border-indigo-500 bg-indigo-50 text-indigo-600' : 'border-gray-200 text-gray-600 hover:border-gray-300'
+                            }`}
+                          >
+                            {t.label}
+                          </button>
+                        ))}
+                      </div>
+                    </div>
+                    <div>
+                      <label className="block text-sm font-medium text-gray-700 mb-2">Couleur accent</label>
+                      <div className="flex gap-2">
+                        <input type="color" value={form.accentColor} onChange={e => update('accentColor', e.target.value)}
+                          className="h-9 w-10 border border-gray-300 rounded-lg cursor-pointer p-0.5" />
+                        <input type="text" value={form.accentColor} onChange={e => update('accentColor', e.target.value)}
+                          className="flex-1 border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 font-mono" />
+                      </div>
+                    </div>
+                  </div>
+
+                  {/* Header design */}
+                  <div className="border-t border-gray-100 pt-5">
+                    <h3 className="text-sm font-semibold text-gray-800 mb-3">Design de l'en-tête</h3>
+                    <div className="space-y-3">
+                      <div className="flex items-center justify-between">
+                        <label className="text-sm text-gray-600">Afficher l'en-tête</label>
+                        <Toggle checked={form.showHeader} onChange={v => update('showHeader', v)} />
+                      </div>
+                      {form.showHeader && (
+                        <div>
+                          <label className="block text-xs text-gray-500 mb-1">Titre personnalisé</label>
+                          <input
+                            type="text"
+                            value={form.headerTitle}
+                            onChange={e => update('headerTitle', e.target.value)}
+                            placeholder="Laissez vide pour utiliser le nom du widget"
+                            className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                          />
+                        </div>
+                      )}
+                    </div>
+                  </div>
+
+                  {/* Reviews design */}
+                  {form.layout !== 'badge' && (
+                    <div className="border-t border-gray-100 pt-5">
+                      <h3 className="text-sm font-semibold text-gray-800 mb-3">Design des avis</h3>
+                      <div className="space-y-3">
+                        <div className="flex items-center justify-between">
+                          <label className="text-sm text-gray-600">Afficher les avatars</label>
+                          <Toggle checked={form.showAvatar} onChange={v => update('showAvatar', v)} />
+                        </div>
+                        <div className="flex items-center justify-between">
+                          <label className="text-sm text-gray-600">Afficher la date</label>
+                          <Toggle checked={form.showDate} onChange={v => update('showDate', v)} />
+                        </div>
+                        {(form.layout === 'list' || form.layout === 'grid' || form.layout === 'slider') && (
+                          <div className="flex items-center justify-between">
+                            <label className="text-sm text-gray-600">Tronquer le texte long</label>
+                            <Toggle checked={form.truncateText} onChange={v => update('truncateText', v)} />
+                          </div>
+                        )}
+                      </div>
+                    </div>
                   )}
-                </div>
-                {form.placeId && (
-                  <p className="text-xs text-green-600 mt-1">✓ {form.placeDescription}</p>
-                )}
-              </div>
-              {error && <p className="text-red-500 text-sm bg-red-50 px-3 py-2 rounded-lg">{error}</p>}
-            </div>
-          )}
 
-          {/* Étape 3 — Paramètres */}
-          {step === 3 && (
-            <div className="space-y-5">
-              <div>
-                <h2 className="font-semibold text-gray-900 mb-1">Paramètres complémentaires</h2>
-                <p className="text-xs text-gray-400 mb-4">Tous les champs sont optionnels.</p>
-              </div>
-
-              <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">Nom du widget</label>
-                <input
-                  type="text"
-                  value={form.name}
-                  onChange={e => update('name', e.target.value)}
-                  placeholder={form.placeName || 'Ex: Avis Google — Mon Restaurant'}
-                  className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
-                />
-                <p className="text-xs text-gray-400 mt-1">Si vide, le nom du lieu sera utilisé.</p>
-              </div>
-
-              <div className="grid grid-cols-2 gap-4">
-                <div>
-                  <label className="block text-sm font-medium text-gray-700 mb-1">Nombre d'avis max</label>
-                  <select
-                    value={form.maxReviews}
-                    onChange={e => update('maxReviews', parseInt(e.target.value))}
-                    className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
-                  >
-                    {[3, 5, 10].map(n => <option key={n} value={n}>{n} avis</option>)}
-                  </select>
-                </div>
-                <div>
-                  <label className="block text-sm font-medium text-gray-700 mb-1">Note minimale</label>
-                  <select
-                    value={form.minRating}
-                    onChange={e => update('minRating', parseInt(e.target.value))}
-                    className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
-                  >
-                    {[1, 2, 3, 4, 5].map(n => <option key={n} value={n}>{n}★ et +</option>)}
-                  </select>
-                </div>
-              </div>
-
-              <div className="grid grid-cols-2 gap-4">
-                <div>
-                  <label className="block text-sm font-medium text-gray-700 mb-1">Thème</label>
-                  <select
-                    value={form.theme}
-                    onChange={e => update('theme', e.target.value)}
-                    className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
-                  >
-                    <option value="light">Clair</option>
-                    <option value="dark">Sombre</option>
-                  </select>
-                </div>
-                <div>
-                  <label className="block text-sm font-medium text-gray-700 mb-1">Couleur accent</label>
-                  <div className="flex gap-2">
-                    <input
-                      type="color"
-                      value={form.accentColor}
-                      onChange={e => update('accentColor', e.target.value)}
-                      className="h-9 w-10 border border-gray-300 rounded-lg cursor-pointer p-0.5"
-                    />
-                    <input
-                      type="text"
-                      value={form.accentColor}
-                      onChange={e => update('accentColor', e.target.value)}
-                      className="flex-1 border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 font-mono"
-                    />
+                  {/* Mobile preview */}
+                  <div className="xl:hidden border-t border-gray-100 pt-5">
+                    <p className="text-xs text-gray-500 mb-3 font-medium uppercase tracking-wide">Aperçu</p>
+                    <LivePreview {...previewProps} />
                   </div>
                 </div>
+              )}
+
+              {/* Étape 2 — Localisation */}
+              {step === 2 && (
+                <div className="space-y-4">
+                  <div>
+                    <h2 className="font-semibold text-gray-900 mb-1">Quel établissement ?</h2>
+                    <p className="text-xs text-gray-400 mb-4">Recherchez votre établissement par son nom.</p>
+                  </div>
+                  <div>
+                    <label className="block text-sm font-medium text-gray-700 mb-1">Lieu</label>
+                    <div className="relative" ref={dropdownRef}>
+                      <input
+                        type="text"
+                        value={search}
+                        onChange={e => handleSearchChange(e.target.value)}
+                        onFocus={() => suggestions.length > 0 && setShowDropdown(true)}
+                        placeholder="Ex: Boulangerie Martin, Paris…"
+                        className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                        autoComplete="off"
+                        autoFocus
+                      />
+                      {searching && <span className="absolute right-3 top-2.5 text-gray-400 text-xs">Recherche…</span>}
+                      {showDropdown && (
+                        <ul className="absolute z-10 mt-1 w-full bg-white border border-gray-200 rounded-lg shadow-lg max-h-56 overflow-y-auto">
+                          {suggestions.map(place => (
+                            <li
+                              key={place.place_id}
+                              onMouseDown={() => selectPlace(place)}
+                              className="px-4 py-3 cursor-pointer hover:bg-indigo-50 border-b border-gray-100 last:border-0"
+                            >
+                              <p className="text-sm font-medium text-gray-900">{place.main_text}</p>
+                              <p className="text-xs text-gray-400">{place.secondary_text}</p>
+                            </li>
+                          ))}
+                        </ul>
+                      )}
+                    </div>
+                    {form.placeId && (
+                      <p className="text-xs text-green-600 mt-1">✓ {form.placeDescription}</p>
+                    )}
+                  </div>
+                  {error && <p className="text-red-500 text-sm bg-red-50 px-3 py-2 rounded-lg">{error}</p>}
+                </div>
+              )}
+
+              {/* Étape 3 — Paramètres */}
+              {step === 3 && (
+                <div className="space-y-5">
+                  <div>
+                    <h2 className="font-semibold text-gray-900 mb-1">Paramètres</h2>
+                    <p className="text-xs text-gray-400 mb-4">Tous les champs sont optionnels.</p>
+                  </div>
+
+                  <div>
+                    <label className="block text-sm font-medium text-gray-700 mb-1">Nom du widget</label>
+                    <input
+                      type="text"
+                      value={form.name}
+                      onChange={e => update('name', e.target.value)}
+                      placeholder={form.placeName || 'Ex: Avis Google — Mon Restaurant'}
+                      className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                    />
+                    <p className="text-xs text-gray-400 mt-1">Si vide, le nom du lieu sera utilisé.</p>
+                  </div>
+
+                  <div className="grid grid-cols-2 gap-4">
+                    <div>
+                      <label className="block text-sm font-medium text-gray-700 mb-1">Nombre d'avis max</label>
+                      <select
+                        value={form.maxReviews}
+                        onChange={e => update('maxReviews', parseInt(e.target.value))}
+                        className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                      >
+                        {[3, 5, 10].map(n => <option key={n} value={n}>{n} avis</option>)}
+                      </select>
+                    </div>
+                    <div>
+                      <label className="block text-sm font-medium text-gray-700 mb-1">Note minimale</label>
+                      <select
+                        value={form.minRating}
+                        onChange={e => update('minRating', parseInt(e.target.value))}
+                        className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                      >
+                        {[1, 2, 3, 4, 5].map(n => <option key={n} value={n}>{n}★ et +</option>)}
+                      </select>
+                    </div>
+                  </div>
+
+                  {error && <p className="text-red-500 text-sm bg-red-50 px-3 py-2 rounded-lg">{error}</p>}
+                </div>
+              )}
+
+              {/* Navigation */}
+              <div className="flex justify-between items-center mt-6 pt-5 border-t border-gray-100">
+                {step > 1 ? (
+                  <button type="button" onClick={() => setStep(s => s - 1)} className="text-sm text-gray-500 hover:text-gray-700">
+                    ← Précédent
+                  </button>
+                ) : (
+                  <Link to="/" className="text-sm text-gray-500 hover:text-gray-700">Annuler</Link>
+                )}
+
+                {step < 3 ? (
+                  <button
+                    type="button"
+                    onClick={nextStep}
+                    className="bg-indigo-600 text-white px-6 py-2 rounded-lg text-sm font-medium hover:bg-indigo-700 transition-colors"
+                  >
+                    Suivant →
+                  </button>
+                ) : (
+                  <button
+                    type="button"
+                    onClick={handleSubmit}
+                    disabled={loading}
+                    className="bg-indigo-600 text-white px-6 py-2 rounded-lg text-sm font-medium hover:bg-indigo-700 disabled:opacity-50 transition-colors"
+                  >
+                    {loading ? 'Création…' : 'Créer le widget'}
+                  </button>
+                )}
               </div>
-
-              {error && <p className="text-red-500 text-sm bg-red-50 px-3 py-2 rounded-lg">{error}</p>}
             </div>
-          )}
-
-          {/* Navigation */}
-          <div className="flex justify-between items-center mt-6 pt-5 border-t border-gray-100">
-            {step > 1 ? (
-              <button type="button" onClick={() => setStep(s => s - 1)} className="text-sm text-gray-500 hover:text-gray-700">
-                ← Précédent
-              </button>
-            ) : (
-              <Link to="/" className="text-sm text-gray-500 hover:text-gray-700">Annuler</Link>
-            )}
-
-            {step < 3 ? (
-              <button
-                type="button"
-                onClick={nextStep}
-                className="bg-indigo-600 text-white px-6 py-2 rounded-lg text-sm font-medium hover:bg-indigo-700 transition-colors"
-              >
-                Suivant →
-              </button>
-            ) : (
-              <button
-                type="button"
-                onClick={handleSubmit}
-                disabled={loading}
-                className="bg-indigo-600 text-white px-6 py-2 rounded-lg text-sm font-medium hover:bg-indigo-700 disabled:opacity-50 transition-colors"
-              >
-                {loading ? 'Création…' : 'Créer le widget'}
-              </button>
-            )}
           </div>
+
+          {/* Right: sticky preview (xl screens) */}
+          <div className="hidden xl:block xl:w-96 flex-shrink-0">
+            <div className="sticky top-6">
+              <p className="text-xs text-gray-500 mb-3 font-medium uppercase tracking-wide">Aperçu en temps réel</p>
+              <LivePreview {...previewProps} />
+            </div>
+          </div>
+
         </div>
       </main>
     </div>

--- a/apps/frontend/src/pages/NewWidget.tsx
+++ b/apps/frontend/src/pages/NewWidget.tsx
@@ -92,7 +92,9 @@ function CardHeader({ review, isDark, showAvatar, avatarSize = 36 }: {
   return (
     <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 10 }}>
       {showAvatar && (
-        <div style={{ width: avatarSize, height: avatarSize, borderRadius: '50%', background: isDark ? '#374151' : '#E5E7EB', flexShrink: 0 }} />
+        review.profile_photo_url
+          ? <img src={review.profile_photo_url} alt="" style={{ width: avatarSize, height: avatarSize, borderRadius: '50%', objectFit: 'cover', flexShrink: 0 }} onError={(e) => { (e.target as HTMLImageElement).style.display = 'none'; }} />
+          : <div style={{ width: avatarSize, height: avatarSize, borderRadius: '50%', background: isDark ? '#374151' : '#E5E7EB', flexShrink: 0 }} />
       )}
       <div>
         <div style={{ fontWeight: 600, fontSize: avatarSize === 32 ? 13 : 14, color: textColor }}>{review.author_name}</div>
@@ -140,7 +142,11 @@ function ReviewCardStars({ review, isDark, showAvatar, showDate }: {
   const subColor = isDark ? '#9CA3AF' : '#6B7280';
   return (
     <div style={{ display: 'flex', alignItems: 'center', gap: 10, padding: '10px 0', borderBottom: `1px solid ${border}` }}>
-      {showAvatar && <div style={{ width: 32, height: 32, borderRadius: '50%', background: isDark ? '#374151' : '#E5E7EB', flexShrink: 0 }} />}
+      {showAvatar && (
+        review.profile_photo_url
+          ? <img src={review.profile_photo_url} alt="" style={{ width: 32, height: 32, borderRadius: '50%', objectFit: 'cover', flexShrink: 0 }} onError={(e) => { (e.target as HTMLImageElement).style.display = 'none'; }} />
+          : <div style={{ width: 32, height: 32, borderRadius: '50%', background: isDark ? '#374151' : '#E5E7EB', flexShrink: 0 }} />
+      )}
       <span style={{ fontWeight: 600, fontSize: 14, color: textColor, flex: 1 }}>{review.author_name}</span>
       <StarRating rating={review.rating} />
       {showDate && review.relative_time_description && <span style={{ fontSize: 12, color: subColor, whiteSpace: 'nowrap' }}>{review.relative_time_description}</span>}
@@ -191,8 +197,6 @@ export function LivePreview({ reviews, layout, theme, accentColor, widgetName, s
   showHeader: boolean; headerTitle: string; showAvatar: boolean; showDate: boolean; truncateText: boolean;
 }) {
   const isDark = theme === 'dark';
-  const bg = isDark ? '#1F2937' : '#FFFFFF';
-  const border = isDark ? '#374151' : '#E5E7EB';
   const subColor = isDark ? '#9CA3AF' : '#6B7280';
   const title = headerTitle || widgetName;
 
@@ -221,7 +225,7 @@ export function LivePreview({ reviews, layout, theme, accentColor, widgetName, s
   }
 
   return (
-    <div style={{ fontFamily: 'system-ui,-apple-system,sans-serif', background: bg, borderRadius: 12, padding: 24, border: `1px solid ${border}` }}>
+    <div style={{ fontFamily: 'system-ui,-apple-system,sans-serif' }}>
       {showHeader && <h3 style={{ color: accentColor, margin: '0 0 20px', fontSize: 18, fontWeight: 700 }}>{title}</h3>}
       {renderReviews()}
       <div style={{ textAlign: 'center', marginTop: 16, fontSize: 11, color: subColor }}>Powered by WebWidget</div>
@@ -517,7 +521,9 @@ export default function NewWidget() {
                   {/* Mobile preview */}
                   <div className="xl:hidden border-t border-gray-100 pt-5">
                     <p className="text-xs text-gray-500 mb-3 font-medium uppercase tracking-wide">Aperçu</p>
-                    <LivePreview {...previewProps} />
+                    <div className="bg-gray-100 rounded-xl p-5 border border-dashed border-gray-300">
+                      <LivePreview {...previewProps} />
+                    </div>
                   </div>
                 </div>
               )}
@@ -649,7 +655,9 @@ export default function NewWidget() {
           <div className="hidden xl:block xl:w-96 flex-shrink-0">
             <div className="sticky top-6">
               <p className="text-xs text-gray-500 mb-3 font-medium uppercase tracking-wide">Aperçu en temps réel</p>
-              <LivePreview {...previewProps} />
+              <div className="bg-gray-100 rounded-xl p-5 border border-dashed border-gray-300">
+                <LivePreview {...previewProps} />
+              </div>
             </div>
           </div>
 

--- a/apps/frontend/src/pages/WidgetDetail.tsx
+++ b/apps/frontend/src/pages/WidgetDetail.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState, useRef } from 'react';
 import { useParams, Link, useNavigate } from 'react-router-dom';
 import api from '../lib/api';
+import { LivePreview, StarRating, Toggle, LAYOUTS, FORM_DEFAULTS } from './NewWidget';
 
 interface Review {
   author_name: string;
@@ -11,7 +12,20 @@ interface Review {
 }
 
 interface PreviewData {
-  widget: { id: string; name: string; config: { theme: string; accentColor: string; layout: string } };
+  widget: {
+    id: string;
+    name: string;
+    config: {
+      theme: string;
+      accentColor: string;
+      layout: string;
+      showHeader: boolean;
+      headerTitle: string;
+      showAvatar: boolean;
+      showDate: boolean;
+      truncateText: boolean;
+    };
+  };
   reviews: Review[];
 }
 
@@ -28,90 +42,6 @@ interface PlacePrediction {
   description: string;
   main_text: string;
   secondary_text: string;
-}
-
-function StarRating({ rating }: { rating: number }) {
-  return (
-    <span>
-      {[1, 2, 3, 4, 5].map((i) => (
-        <span key={i} style={{ color: i <= rating ? '#FBBF24' : '#D1D5DB' }}>★</span>
-      ))}
-    </span>
-  );
-}
-
-function ReviewCard({ review, isDark }: { review: Review; isDark: boolean }) {
-  const bg = isDark ? '#111827' : '#F9FAFB';
-  const border = isDark ? '#374151' : '#E5E7EB';
-  const textColor = isDark ? '#F9FAFB' : '#111827';
-  const subColor = isDark ? '#9CA3AF' : '#6B7280';
-
-  return (
-    <div style={{ padding: 16, background: bg, borderRadius: 8, border: `1px solid ${border}`, marginBottom: 12 }}>
-      <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 10 }}>
-        {review.profile_photo_url && (
-          <img
-            src={review.profile_photo_url}
-            alt={review.author_name}
-            style={{ width: 36, height: 36, borderRadius: '50%', objectFit: 'cover', flexShrink: 0 }}
-            onError={(e) => { (e.target as HTMLImageElement).style.display = 'none'; }}
-          />
-        )}
-        <div>
-          <div style={{ fontWeight: 600, fontSize: 14, color: textColor }}>{review.author_name}</div>
-          <StarRating rating={review.rating} />
-        </div>
-      </div>
-      {review.text && (
-        <p style={{ color: subColor, margin: 0, fontSize: 14, lineHeight: 1.6 }}>{review.text}</p>
-      )}
-      {review.relative_time_description && (
-        <div style={{ color: subColor, fontSize: 12, marginTop: 8 }}>{review.relative_time_description}</div>
-      )}
-    </div>
-  );
-}
-
-function ReviewCardGrid({ review, isDark }: { review: Review; isDark: boolean }) {
-  const bg = isDark ? '#111827' : '#F9FAFB';
-  const border = isDark ? '#374151' : '#E5E7EB';
-  const textColor = isDark ? '#F9FAFB' : '#111827';
-  const subColor = isDark ? '#9CA3AF' : '#6B7280';
-  return (
-    <div style={{ padding: 16, background: bg, borderRadius: 8, border: `1px solid ${border}`, display: 'flex', flexDirection: 'column' }}>
-      <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 10 }}>
-        {review.profile_photo_url && (
-          <img src={review.profile_photo_url} alt={review.author_name}
-            style={{ width: 32, height: 32, borderRadius: '50%', objectFit: 'cover', flexShrink: 0 }}
-            onError={(e) => { (e.target as HTMLImageElement).style.display = 'none'; }} />
-        )}
-        <div>
-          <div style={{ fontWeight: 600, fontSize: 13, color: textColor }}>{review.author_name}</div>
-          <StarRating rating={review.rating} />
-        </div>
-      </div>
-      {review.text && <p style={{ color: subColor, margin: 0, fontSize: 13, lineHeight: 1.5, flex: 1 }}>{review.text}</p>}
-      {review.relative_time_description && <div style={{ color: subColor, fontSize: 11, marginTop: 8 }}>{review.relative_time_description}</div>}
-    </div>
-  );
-}
-
-function ReviewCardStars({ review, isDark }: { review: Review; isDark: boolean }) {
-  const border = isDark ? '#374151' : '#E5E7EB';
-  const textColor = isDark ? '#F9FAFB' : '#111827';
-  const subColor = isDark ? '#9CA3AF' : '#6B7280';
-  return (
-    <div style={{ display: 'flex', alignItems: 'center', gap: 10, padding: '10px 0', borderBottom: `1px solid ${border}` }}>
-      {review.profile_photo_url && (
-        <img src={review.profile_photo_url} alt={review.author_name}
-          style={{ width: 32, height: 32, borderRadius: '50%', objectFit: 'cover', flexShrink: 0 }}
-          onError={(e) => { (e.target as HTMLImageElement).style.display = 'none'; }} />
-      )}
-      <span style={{ fontWeight: 600, fontSize: 14, color: textColor, flex: 1 }}>{review.author_name}</span>
-      <StarRating rating={review.rating} />
-      {review.relative_time_description && <span style={{ fontSize: 12, color: subColor, whiteSpace: 'nowrap' }}>{review.relative_time_description}</span>}
-    </div>
-  );
 }
 
 function WidgetPreview({ widgetId, apiUrl, refreshKey }: { widgetId: string; apiUrl: string; refreshKey: number }) {
@@ -136,34 +66,21 @@ function WidgetPreview({ widgetId, apiUrl, refreshKey }: { widgetId: string; api
   if (error) return <p className="text-sm text-red-500 text-center py-4">Erreur : {error}</p>;
   if (!data) return null;
 
-  const { theme, accentColor, layout } = data.widget.config;
-  const reviews = data.reviews;
-  const isDark = theme === 'dark';
-  const bg = isDark ? '#1F2937' : '#FFFFFF';
-  const border = isDark ? '#374151' : '#E5E7EB';
-  const subColor = isDark ? '#9CA3AF' : '#6B7280';
-
-  function renderReviews() {
-    if (reviews.length === 0) return <p style={{ color: subColor }}>Aucun avis disponible.</p>;
-    if (layout === 'grid') {
-      return (
-        <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 12 }}>
-          {reviews.map((r, i) => <ReviewCardGrid key={i} review={r} isDark={isDark} />)}
-        </div>
-      );
-    }
-    if (layout === 'stars') {
-      return <div>{reviews.map((r, i) => <ReviewCardStars key={i} review={r} isDark={isDark} />)}</div>;
-    }
-    return <div>{reviews.map((r, i) => <ReviewCard key={i} review={r} isDark={isDark} />)}</div>;
-  }
+  const c = data.widget.config;
 
   return (
-    <div style={{ fontFamily: 'system-ui,-apple-system,sans-serif', background: bg, borderRadius: 12, padding: 24, border: `1px solid ${border}` }}>
-      <h3 style={{ color: accentColor, margin: '0 0 20px', fontSize: 18, fontWeight: 700 }}>{data.widget.name}</h3>
-      {renderReviews()}
-      <div style={{ textAlign: 'center', marginTop: 16, fontSize: 11, color: subColor }}>Powered by WebWidget</div>
-    </div>
+    <LivePreview
+      reviews={data.reviews}
+      layout={c.layout || 'list'}
+      theme={c.theme || 'light'}
+      accentColor={c.accentColor || '#4F46E5'}
+      widgetName={data.widget.name}
+      showHeader={c.showHeader !== false}
+      headerTitle={c.headerTitle || ''}
+      showAvatar={c.showAvatar !== false}
+      showDate={c.showDate !== false}
+      truncateText={c.truncateText !== false}
+    />
   );
 }
 
@@ -208,18 +125,23 @@ export default function WidgetDetail() {
 
   function startEditing() {
     if (!widget) return;
-    const config = widget.config as any;
+    const c = widget.config as any;
     setEditForm({
       name: widget.name,
-      placeId: config.placeId,
-      placeDescription: config.placeDescription || '',
-      layout: config.layout || 'list',
-      maxReviews: config.maxReviews,
-      minRating: config.minRating,
-      theme: config.theme,
-      accentColor: config.accentColor,
+      placeId: c.placeId,
+      placeDescription: c.placeDescription || '',
+      layout: c.layout || 'list',
+      maxReviews: c.maxReviews ?? FORM_DEFAULTS.maxReviews,
+      minRating: c.minRating ?? FORM_DEFAULTS.minRating,
+      theme: c.theme || FORM_DEFAULTS.theme,
+      accentColor: c.accentColor || FORM_DEFAULTS.accentColor,
+      showHeader: c.showHeader !== false,
+      headerTitle: c.headerTitle || '',
+      showAvatar: c.showAvatar !== false,
+      showDate: c.showDate !== false,
+      truncateText: c.truncateText !== false,
     });
-    setSearch(config.placeDescription || '');
+    setSearch(c.placeDescription || '');
     setEditing(true);
     setEditError('');
   }
@@ -309,6 +231,24 @@ export default function WidgetDetail() {
 
   const config = widget.config as any;
 
+  const layoutLabel: Record<string, string> = {
+    list: 'Liste', grid: 'Grille', stars: 'Étoiles', slider: 'Slider', badge: 'Badge',
+  };
+
+  // Live preview props for edit mode
+  const editPreviewProps = editing ? {
+    reviews: [],
+    layout: editForm.layout || 'list',
+    theme: editForm.theme || 'light',
+    accentColor: editForm.accentColor || '#4F46E5',
+    widgetName: editForm.name || widget.name,
+    showHeader: editForm.showHeader !== false,
+    headerTitle: editForm.headerTitle || '',
+    showAvatar: editForm.showAvatar !== false,
+    showDate: editForm.showDate !== false,
+    truncateText: editForm.truncateText !== false,
+  } : null;
+
   return (
     <div className="min-h-screen bg-gray-50">
       <header className="bg-white border-b border-gray-200">
@@ -376,7 +316,9 @@ export default function WidgetDetail() {
           </div>
 
           {editing ? (
-            <div className="space-y-4">
+            <div className="space-y-5">
+
+              {/* Nom */}
               <div>
                 <label className="block text-xs text-gray-500 mb-1">Nom du widget</label>
                 <input
@@ -387,6 +329,7 @@ export default function WidgetDetail() {
                 />
               </div>
 
+              {/* Lieu */}
               <div>
                 <label className="block text-xs text-gray-500 mb-1">Lieu</label>
                 <div className="relative" ref={dropdownRef}>
@@ -422,19 +365,16 @@ export default function WidgetDetail() {
                 )}
               </div>
 
+              {/* Layout */}
               <div>
-                <label className="block text-xs text-gray-500 mb-2">Design</label>
-                <div className="grid grid-cols-3 gap-2">
-                  {[
-                    { value: 'list', label: 'Liste' },
-                    { value: 'grid', label: 'Grille' },
-                    { value: 'stars', label: 'Étoiles' },
-                  ].map((l) => (
+                <label className="block text-xs text-gray-500 mb-2">Mise en page</label>
+                <div className="grid grid-cols-3 sm:grid-cols-5 gap-2">
+                  {LAYOUTS.map((l) => (
                     <button
                       key={l.value}
                       type="button"
                       onClick={() => updateField('layout', l.value)}
-                      className={`py-2 rounded-lg border-2 text-xs font-medium transition-all ${
+                      className={`p-2 rounded-lg border-2 text-xs font-medium transition-all ${
                         editForm.layout === l.value
                           ? 'border-indigo-500 bg-indigo-50 text-indigo-600'
                           : 'border-gray-200 text-gray-500 hover:border-gray-300'
@@ -446,6 +386,7 @@ export default function WidgetDetail() {
                 </div>
               </div>
 
+              {/* Filters */}
               <div className="grid grid-cols-2 gap-4">
                 <div>
                   <label className="block text-xs text-gray-500 mb-1">Avis max</label>
@@ -469,6 +410,7 @@ export default function WidgetDetail() {
                 </div>
               </div>
 
+              {/* Theme + color */}
               <div className="grid grid-cols-2 gap-4">
                 <div>
                   <label className="block text-xs text-gray-500 mb-1">Thème</label>
@@ -500,6 +442,52 @@ export default function WidgetDetail() {
                 </div>
               </div>
 
+              {/* Header design */}
+              <div className="border-t border-gray-100 pt-4">
+                <p className="text-xs font-semibold text-gray-700 mb-3">En-tête</p>
+                <div className="space-y-3">
+                  <div className="flex items-center justify-between">
+                    <label className="text-sm text-gray-600">Afficher l'en-tête</label>
+                    <Toggle checked={editForm.showHeader !== false} onChange={v => updateField('showHeader', v)} />
+                  </div>
+                  {editForm.showHeader !== false && (
+                    <div>
+                      <label className="block text-xs text-gray-500 mb-1">Titre personnalisé</label>
+                      <input
+                        type="text"
+                        value={editForm.headerTitle || ''}
+                        onChange={(e) => updateField('headerTitle', e.target.value)}
+                        placeholder="Laissez vide pour utiliser le nom du widget"
+                        className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                      />
+                    </div>
+                  )}
+                </div>
+              </div>
+
+              {/* Reviews design */}
+              {editForm.layout !== 'badge' && (
+                <div className="border-t border-gray-100 pt-4">
+                  <p className="text-xs font-semibold text-gray-700 mb-3">Design des avis</p>
+                  <div className="space-y-3">
+                    <div className="flex items-center justify-between">
+                      <label className="text-sm text-gray-600">Afficher les avatars</label>
+                      <Toggle checked={editForm.showAvatar !== false} onChange={v => updateField('showAvatar', v)} />
+                    </div>
+                    <div className="flex items-center justify-between">
+                      <label className="text-sm text-gray-600">Afficher la date</label>
+                      <Toggle checked={editForm.showDate !== false} onChange={v => updateField('showDate', v)} />
+                    </div>
+                    {(editForm.layout === 'list' || editForm.layout === 'grid' || editForm.layout === 'slider') && (
+                      <div className="flex items-center justify-between">
+                        <label className="text-sm text-gray-600">Tronquer le texte long</label>
+                        <Toggle checked={editForm.truncateText !== false} onChange={v => updateField('truncateText', v)} />
+                      </div>
+                    )}
+                  </div>
+                </div>
+              )}
+
               {editError && (
                 <p className="text-red-500 text-sm bg-red-50 px-3 py-2 rounded-lg">{editError}</p>
               )}
@@ -529,12 +517,8 @@ export default function WidgetDetail() {
                 </div>
               )}
               <div>
-                <dt className="text-gray-500 text-xs mb-0.5">Place ID</dt>
-                <dd className="font-mono text-gray-900 text-xs truncate">{config.placeId}</dd>
-              </div>
-              <div>
-                <dt className="text-gray-500 text-xs mb-0.5">Design</dt>
-                <dd className="text-gray-900">{{ list: 'Liste', grid: 'Grille', stars: 'Étoiles' }[config.layout as string] || 'Liste'}</dd>
+                <dt className="text-gray-500 text-xs mb-0.5">Mise en page</dt>
+                <dd className="text-gray-900">{layoutLabel[config.layout as string] || 'Liste'}</dd>
               </div>
               <div>
                 <dt className="text-gray-500 text-xs mb-0.5">Avis max</dt>
@@ -552,13 +536,22 @@ export default function WidgetDetail() {
                 <div>
                   <dt className="text-gray-500 text-xs mb-0.5">Couleur accent</dt>
                   <dd className="flex items-center gap-2">
-                    <span
-                      className="inline-block w-4 h-4 rounded border border-gray-200"
-                      style={{ background: config.accentColor }}
-                    />
+                    <span className="inline-block w-4 h-4 rounded border border-gray-200" style={{ background: config.accentColor }} />
                     <span className="text-gray-900 font-mono text-xs">{config.accentColor}</span>
                   </dd>
                 </div>
+              </div>
+              <div>
+                <dt className="text-gray-500 text-xs mb-0.5">En-tête</dt>
+                <dd className="text-gray-900">{config.showHeader === false ? 'Masqué' : 'Affiché'}</dd>
+              </div>
+              <div>
+                <dt className="text-gray-500 text-xs mb-0.5">Avatars</dt>
+                <dd className="text-gray-900">{config.showAvatar === false ? 'Masqués' : 'Affichés'}</dd>
+              </div>
+              <div>
+                <dt className="text-gray-500 text-xs mb-0.5">Dates</dt>
+                <dd className="text-gray-900">{config.showDate === false ? 'Masquées' : 'Affichées'}</dd>
               </div>
             </dl>
           )}


### PR DESCRIPTION
## Summary

**Nouveaux layouts :**
- **Slider** : cartes en défilement horizontal avec scroll-snap
- **Badge** : synthèse compacte avec note moyenne, étoiles et compteur d'avis

**Design de l'en-tête :**
- Toggle afficher/masquer l'en-tête
- Champ titre personnalisé (laissé vide = nom du widget)

**Design des avis :**
- Toggle afficher/masquer les avatars
- Toggle afficher/masquer les dates
- Toggle tronquer/afficher le texte complet (layouts list, grid, slider)

**Technique :**
- `NewWidget.tsx` : picker 5 layouts, toggles dans l'étape 1, exports partagés (`LivePreview`, `Toggle`, `LAYOUTS`…), preview côte à côte incluse
- `WidgetDetail.tsx` : formulaire d'édition mis à jour, importe les composants partagés
- `widget.js` : `renderBadge`, `renderCardSlider`, toutes les fonctions `render*` acceptent `showAvatar`/`showDate`/`truncateText` ; `renderWidget` lit les nouvelles clés de config
- Rétrocompatible : les widgets existants sans ces champs utilisent les valeurs par défaut (`true`)

## Test plan

- [ ] Nouveau widget avec layout Slider → défilement horizontal dans la preview et en intégration
- [ ] Nouveau widget avec layout Badge → synthèse compacte affichée
- [ ] Désactiver l'en-tête → le titre disparaît dans la preview et dans le widget intégré
- [ ] Titre personnalisé → affiché à la place du nom du widget
- [ ] Désactiver avatars/dates → masqués dans la preview et en intégration
- [ ] Tronquer le texte → les longs avis sont limités à 3 lignes
- [ ] Widget existant (sans les nouvelles clés) → comportement identique à avant

🤖 Generated with [Claude Code](https://claude.com/claude-code)