### PR TITLE
feat(#7): image Docker all-in-one + compose prod & coolify

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,20 +1,45 @@
-# Identifiants admin (chargés depuis les variables d'environnement)
+# ================================================================
+# WebWidget Tool — Variables d'environnement
+# Copiez ce fichier en .env et remplissez les valeurs.
+# ================================================================
+
+# --- Admin ---
 ADMIN_EMAIL=admin@example.com
 ADMIN_PASSWORD=changeme
 
-# Clé secrète JWT (changez en production !)
+# --- Sécurité ---
+# Générez une clé aléatoire en production : openssl rand -hex 32
 JWT_SECRET=supersecretkey_change_in_production
 
-# URL publique du backend (utilisée dans les snippets d'intégration)
-# En local : http://localhost:4000
-# En production : https://api.votre-domaine.com
+# --- Google Places API ---
+# Clé API Google Maps avec l'API Places activée
+GOOGLE_MAPS_API_KEY=
+
+# Durée du cache des avis Google en secondes (défaut : 7 jours)
+GOOGLE_REVIEWS_CACHE_TTL=604800
+
+# ================================================================
+# Mode 2 conteneurs (docker-compose.yml — développement / legacy)
+# ================================================================
+
+# URL publique du backend (baked dans le build React via Vite)
+# Ex: http://localhost:4000 en local, https://api.monsite.com en prod
 VITE_API_URL=http://localhost:4000
 
 # URL du frontend (pour CORS côté backend)
 FRONTEND_URL=http://localhost:3000
 
-# Clé API Google Maps (doit avoir Places API activée)
-GOOGLE_MAPS_API_KEY=
+# ================================================================
+# Mode all-in-one (docker-compose.prod.yml)
+# ================================================================
 
-# Durée du cache des avis Google en secondes (défaut : 1h)
-GOOGLE_REVIEWS_CACHE_TTL=3600
+# URL publique de l'application (ex: https://widgets.monsite.com)
+# Utilisée pour CORS et dans les snippets d'intégration.
+APP_URL=http://localhost:3000
+
+# Port exposé sur l'hôte (défaut : 3000)
+PORT=3000
+
+# Mot de passe PostgreSQL (obligatoire en prod)
+POSTGRES_PASSWORD=changeme
+POSTGRES_USER=postgres

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,68 @@
+# =============================================================================
+# WebWidget Tool — All-in-one image
+# Builds the React frontend and bundles it inside the Node.js backend.
+# A single container serves both the dashboard SPA and the API.
+# =============================================================================
+
+# -------------------------------------------
+# Stage 1 — Build frontend
+# -------------------------------------------
+FROM node:20-alpine AS frontend-builder
+
+WORKDIR /app/frontend
+
+COPY apps/frontend/package*.json ./
+RUN npm install
+
+COPY apps/frontend/ .
+
+# In all-in-one mode the API is on the same origin, so VITE_API_URL is empty.
+# The frontend falls back to window.location.origin automatically.
+ARG VITE_API_URL=
+ENV VITE_API_URL=$VITE_API_URL
+
+RUN npm run build
+
+# -------------------------------------------
+# Stage 2 — Build backend
+# -------------------------------------------
+FROM node:20-alpine AS backend-builder
+
+RUN apk add --no-cache openssl
+
+WORKDIR /app/backend
+
+COPY apps/backend/package*.json ./
+COPY apps/backend/prisma ./prisma/
+
+RUN npm install
+RUN npx prisma generate
+
+COPY apps/backend/tsconfig.json ./
+COPY apps/backend/src ./src
+COPY apps/backend/public ./public
+
+RUN npm run build
+
+# -------------------------------------------
+# Stage 3 — Runtime
+# -------------------------------------------
+FROM node:20-alpine
+
+RUN apk add --no-cache openssl
+
+WORKDIR /app
+
+# Copy backend artifacts
+COPY --from=backend-builder /app/backend/node_modules ./node_modules
+COPY --from=backend-builder /app/backend/dist         ./dist
+COPY --from=backend-builder /app/backend/public       ./public
+COPY --from=backend-builder /app/backend/prisma       ./prisma
+
+# Embed the frontend build inside public/app/
+# The backend will detect this folder and serve the SPA automatically.
+COPY --from=frontend-builder /app/frontend/dist ./public/app
+
+EXPOSE 4000
+
+CMD ["sh", "-c", "npx prisma migrate deploy && node dist/index.js"]

--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
 # WebWidget Tool
 
-Outil open-source pour créer et gérer des widgets intégrables dans n'importe quel site HTML.
+Outil open-source pour créer et gérer des widgets d'avis Google intégrables dans n'importe quel site HTML.
 
-## Démarrage rapide
+## Démarrage rapide (développement)
 
 ```bash
 # 1. Copier et configurer les variables d'environnement
 cp .env.example .env
 # Éditez .env avec vos valeurs
 
-# 2. Lancer l'application
+# 2. Lancer l'application (2 conteneurs : frontend + backend)
 docker compose up --build
 
 # 3. Accéder au dashboard
@@ -18,23 +18,93 @@ open http://localhost:3000
 
 Connectez-vous avec les identifiants définis dans `.env` (`ADMIN_EMAIL` / `ADMIN_PASSWORD`).
 
+---
+
+## Modes de déploiement
+
+### Mode 2 conteneurs — développement / legacy
+
+Le fichier `docker-compose.yml` lance **3 services** : PostgreSQL, backend Node.js (port 4000) et frontend Nginx (port 3000).
+
+```bash
+docker compose up --build -d
+```
+
+### Mode all-in-one — production recommandée
+
+Le fichier `Dockerfile` (racine) compile le frontend React et l'embarque dans l'image Node.js. Un seul conteneur sert à la fois le dashboard et l'API sur le **port 4000**.
+
+```bash
+# Copier et remplir les variables de prod
+cp .env.example .env.prod
+# Éditez APP_URL, ADMIN_PASSWORD, JWT_SECRET, GOOGLE_MAPS_API_KEY, POSTGRES_PASSWORD
+
+docker compose -f docker-compose.prod.yml --env-file .env.prod up --build -d
+```
+
+L'application est accessible sur `http://host:3000` (configurable via `PORT`).
+
+### Déploiement sur Coolify
+
+Coolify gère automatiquement le certificat TLS et le domaine.
+
+1. Créez une ressource **Docker Compose** dans Coolify.
+2. Sélectionnez le fichier `docker-compose.coolify.yml`.
+3. Renseignez les variables d'environnement dans l'interface Coolify :
+
+| Variable | Description |
+|---|---|
+| `ADMIN_EMAIL` | Email de connexion admin |
+| `ADMIN_PASSWORD` | Mot de passe admin |
+| `JWT_SECRET` | Clé secrète JWT |
+| `GOOGLE_MAPS_API_KEY` | Clé API Google Maps (Places activée) |
+| `POSTGRES_PASSWORD` | Mot de passe PostgreSQL |
+| `GOOGLE_REVIEWS_CACHE_TTL` | Cache avis en secondes (défaut : 604800) |
+
+Coolify injecte automatiquement `SERVICE_FQDN_APP_4000` (l'URL publique du service) dans `FRONTEND_URL`.
+
+---
+
 ## Variables d'environnement
+
+### Communes
 
 | Variable | Défaut | Description |
 |---|---|---|
 | `ADMIN_EMAIL` | `admin@example.com` | Email de connexion admin |
 | `ADMIN_PASSWORD` | `changeme` | Mot de passe admin |
-| `JWT_SECRET` | *(voir .env.example)* | Clé secrète JWT (changez en prod !) |
-| `VITE_API_URL` | `http://localhost:4000` | URL publique du backend |
+| `JWT_SECRET` | *(voir .env.example)* | Clé secrète JWT — changez en prod |
+| `GOOGLE_MAPS_API_KEY` | *(vide)* | Clé API Google Maps |
+| `GOOGLE_REVIEWS_CACHE_TTL` | `604800` | Durée du cache avis Google (secondes) |
+
+### Mode 2 conteneurs
+
+| Variable | Défaut | Description |
+|---|---|---|
+| `VITE_API_URL` | `http://localhost:4000` | URL publique du backend (baked dans React) |
 | `FRONTEND_URL` | `http://localhost:3000` | URL du frontend (pour CORS) |
-| `GOOGLE_REVIEWS_CACHE_TTL` | `3600` | Durée du cache avis Google (secondes) |
+
+### Mode all-in-one
+
+| Variable | Défaut | Description |
+|---|---|---|
+| `APP_URL` | `http://localhost:3000` | URL publique de l'application |
+| `PORT` | `3000` | Port exposé sur l'hôte |
+| `POSTGRES_PASSWORD` | `changeme` | Mot de passe PostgreSQL |
+
+---
 
 ## Widgets disponibles
 
 ### Avis Google
+
 Affiche les avis Google d'un établissement. Nécessite :
 - Un **Google Place ID** ([trouver le vôtre](https://developers.google.com/maps/documentation/places/web-service/place-id))
 - Une **clé API Google Maps** avec l'API Places activée
+
+**Mises en page disponibles :** Liste · Grille · Étoiles · Slider · Badge
+
+**Options de design :** thème clair/sombre, couleur accent, affichage de l'en-tête (titre personnalisable), avatars, dates, troncature du texte.
 
 ### Intégration dans votre site
 
@@ -42,22 +112,26 @@ Après avoir créé un widget dans le dashboard, copiez le snippet fourni :
 
 ```html
 <div id="gw-widget"></div>
-<script src="http://localhost:4000/widget.js" data-widget-id="VOTRE_ID"></script>
+<script src="https://votre-app.com/widget.js" data-widget-id="VOTRE_ID"></script>
 ```
+
+---
 
 ## Architecture
 
 ```
 web-widget-tool/
-├── apps/
-│   ├── backend/    # Node.js + Express + TypeScript + Prisma
-│   └── frontend/   # React + TypeScript + Vite + Tailwind
-├── docker-compose.yml
-└── .env.example
+├── Dockerfile                  ← image all-in-one (frontend + backend)
+├── docker-compose.yml          ← développement (2 conteneurs)
+├── docker-compose.prod.yml     ← production all-in-one
+├── docker-compose.coolify.yml  ← déploiement Coolify
+├── .env.example
+└── apps/
+    ├── backend/    # Node.js + Express + TypeScript + Prisma
+    │   ├── src/
+    │   ├── public/ # widget.js (script embeddable)
+    │   └── prisma/
+    └── frontend/   # React + TypeScript + Vite + Tailwind
 ```
 
-## Déploiement en production
-
-1. Définissez `VITE_API_URL` à l'URL publique de votre backend (ex: `https://api.monsite.com`)
-2. Changez `JWT_SECRET` et `ADMIN_PASSWORD` pour des valeurs sécurisées
-3. Lancez `docker compose up --build -d`
+En mode all-in-one, le backend Express détecte la présence de `public/app/index.html` (copiée par le Dockerfile) et active automatiquement le serving du SPA + le fallback HTML5 history.

--- a/apps/backend/src/index.ts
+++ b/apps/backend/src/index.ts
@@ -1,6 +1,7 @@
 import express from 'express';
 import cors from 'cors';
 import path from 'path';
+import fs from 'fs';
 import authRouter from './routes/auth';
 import widgetsRouter from './routes/widgets';
 import placesRouter from './routes/places';
@@ -30,6 +31,17 @@ app.get('/widget.js', openCors, (_, res) => {
 });
 
 app.get('/health', (_, res) => res.json({ status: 'ok' }));
+
+// Serve the React SPA when the frontend is bundled (all-in-one mode).
+// The Dockerfile copies the frontend build to public/app/.
+// In dev (two-container) mode this directory does not exist and this block is skipped.
+const spaDir = path.join(__dirname, '../public/app');
+const spaIndex = path.join(spaDir, 'index.html');
+if (fs.existsSync(spaIndex)) {
+  app.use(express.static(spaDir));
+  // SPA fallback: serve index.html for any route not already handled above
+  app.get('*', (_req, res) => res.sendFile(spaIndex));
+}
 
 app.listen(PORT, () => {
   console.log(`Backend running on port ${PORT}`);

--- a/docker-compose.coolify.yml
+++ b/docker-compose.coolify.yml
@@ -1,0 +1,58 @@
+# =============================================================================
+# Coolify deployment — all-in-one image
+#
+# How to deploy on Coolify:
+#   1. Create a new "Docker Compose" resource in Coolify.
+#   2. Point it to this file (docker-compose.coolify.yml).
+#   3. Set the environment variables listed below in the Coolify UI.
+#   4. Coolify will automatically assign a domain to the `app` service
+#      and inject SERVICE_FQDN_APP_4000 into the environment.
+#
+# The ${SERVICE_FQDN_APP_4000} variable is provided by Coolify and resolves
+# to the public HTTPS URL assigned to port 4000 of the `app` service.
+# =============================================================================
+
+services:
+  postgres:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_USER:     ${POSTGRES_USER:-postgres}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_DB:       widgets
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-postgres}"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+    restart: unless-stopped
+
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    # No `ports` here — Coolify handles ingress and TLS termination.
+    expose:
+      - "4000"
+    environment:
+      DATABASE_URL:             postgresql://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD}@postgres:5432/widgets
+      ADMIN_EMAIL:              ${ADMIN_EMAIL}
+      ADMIN_PASSWORD:           ${ADMIN_PASSWORD}
+      JWT_SECRET:               ${JWT_SECRET}
+      GOOGLE_MAPS_API_KEY:      ${GOOGLE_MAPS_API_KEY}
+      GOOGLE_REVIEWS_CACHE_TTL: ${GOOGLE_REVIEWS_CACHE_TTL:-604800}
+      # Coolify injects the public URL as SERVICE_FQDN_APP_4000
+      FRONTEND_URL:             ${SERVICE_FQDN_APP_4000}
+    depends_on:
+      postgres:
+        condition: service_healthy
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "wget", "-q", "--spider", "http://localhost:4000/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+
+volumes:
+  postgres_data:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,54 @@
+# =============================================================================
+# Production — single all-in-one image
+#
+# Usage:
+#   cp .env.example .env.prod   # fill in all required variables
+#   docker compose -f docker-compose.prod.yml --env-file .env.prod up --build -d
+#
+# The app is reachable on http://host:${PORT:-3000}
+# Put a reverse proxy (Nginx, Caddy, Traefik…) in front for HTTPS.
+# =============================================================================
+
+services:
+  postgres:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_USER:     ${POSTGRES_USER:-postgres}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required}
+      POSTGRES_DB:       widgets
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-postgres}"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+    restart: unless-stopped
+
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    ports:
+      - "${PORT:-3000}:4000"
+    environment:
+      DATABASE_URL:               postgresql://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD}@postgres:5432/widgets
+      ADMIN_EMAIL:                ${ADMIN_EMAIL:?ADMIN_EMAIL is required}
+      ADMIN_PASSWORD:             ${ADMIN_PASSWORD:?ADMIN_PASSWORD is required}
+      JWT_SECRET:                 ${JWT_SECRET:?JWT_SECRET is required}
+      GOOGLE_MAPS_API_KEY:        ${GOOGLE_MAPS_API_KEY}
+      GOOGLE_REVIEWS_CACHE_TTL:   ${GOOGLE_REVIEWS_CACHE_TTL:-604800}
+      # FRONTEND_URL must match the public URL of the app (for CORS on embedded widgets)
+      FRONTEND_URL:               ${APP_URL:-http://localhost:3000}
+    depends_on:
+      postgres:
+        condition: service_healthy
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "wget", "-q", "--spider", "http://localhost:4000/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+
+volumes:
+  postgres_data:


### PR DESCRIPTION
## Summary

**`Dockerfile` (racine) — multi-stage :**
1. Stage frontend : build React avec \`VITE_API_URL=''\` (même origine, pas de variable à fixer)
2. Stage backend : compilation TypeScript + génération Prisma client
3. Stage runtime : image Node.js Alpine légère qui sert API + SPA depuis un seul conteneur sur le port 4000

**Backend (\`apps/backend/src/index.ts\`) :**
- Détecte \`public/app/index.html\` au démarrage
- Si présent → active le serving statique + route fallback pour HTML5 history (SPA mode)
- Transparent en mode dev 2-conteneurs (le dossier n'existe pas)

**Nouveaux fichiers compose :**
- \`docker-compose.prod.yml\` : service unique \`app\`, variables obligatoires avec validation (\`:?\`), healthcheck
- \`docker-compose.coolify.yml\` : \`expose\` au lieu de \`ports\`, \`FRONTEND_URL=${SERVICE_FQDN_APP_4000}\` injecté automatiquement par Coolify

**Documentation :**
- \`README.md\` : section \"Modes de déploiement\" avec les 3 modes (dev, prod, Coolify)
- \`.env.example\` : variables all-in-one documentées (\`APP_URL\`, \`PORT\`, \`POSTGRES_PASSWORD\`)

## Test plan

- [ ] \`docker compose -f docker-compose.prod.yml --env-file .env.prod up --build\` → dashboard accessible sur \`http://localhost:3000\`, snippet d'intégration fonctionnel
- [ ] Un seul conteneur \`app\` (+ postgres) dans \`docker ps\`
- [ ] \`/health\` répond \`{"status":"ok"}\`
- [ ] Navigation SPA (ex: rafraîchir sur \`/widgets/:id\`) → index.html servi correctement
- [ ] Routes API (\`/api/widgets\`) non interceptées par le fallback SPA
- [ ] \`docker-compose.coolify.yml\` valide (pas d'erreur \`docker compose config\`)
- [ ] \`docker-compose.yml\` (dev 2 conteneurs) fonctionne toujours sans régression

🤖 Generated with [Claude Code](https://claude.com/claude-code)